### PR TITLE
VST-patch : Update vstEffect.flags with existing canMono

### DIFF
--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
@@ -369,6 +369,8 @@ public:
         vstEffect.processDoubleReplacing = (Vst2::AEffectProcessDoubleProc) processDoubleReplacingCB;
 
         vstEffect.flags |= Vst2::effFlagsHasEditor;
+        
+        vstEffect.flags |= Vst2::effFlagsCanMono;
 
         vstEffect.flags |= Vst2::effFlagsCanReplacing;
         if (processor->supportsDoublePrecisionProcessing())


### PR DESCRIPTION
**What does this PR do?**
Introduces the patched fix introduced in **JUCE v.5.2.1**  (for VST support with Adobe Premiere's mono clips) to the **v.5.4.7** of our fork. 

This should now allow to load VST effects on mono tracks in Adobe Premiere.

**Where should the reviewer start?**
It seems that the `enum VstEffectInterfaceFlags` that we previously had to modify has been deprecated, so the only necessary change was to add`Vst2::effFlagsCanMono`  (previously `vstEffectFlagCanMono`) to the `vstEffect.flags` of the VST wrapper.