### PR TITLE
force prepare all nodes in AudioProcessorGraph

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp
@@ -1262,6 +1262,17 @@ void AudioProcessorGraph::prepareToPlay (double sampleRate, int estimatedSamples
 
     clearRenderingSequence();
 
+    // Attention: Adobe megahack! 
+    // Force prepare all nodes here!
+    // Why are we doing this? 
+    // Because Premiere might:
+    //  - Trigger async preparation during render
+    //  - Report the isNonRealtime wrong
+    // This means that processing might start taking place before all nodes are
+    // prepped and ready, without a fallback wait/lock
+    for (auto* node : nodes)
+        node->prepare(sampleRate, estimatedSamplesPerBlock, this, getProcessingPrecision());
+
     if (MessageManager::getInstance()->isThisTheMessageThread())
         handleAsyncUpdate();
     else


### PR DESCRIPTION
Details on the reasoning behind this [are found here](https://github.com/accusonus/era-bundle/issues/3214#issuecomment-723590202)

As far as "safety" goes, I've been building plugins from this branch for the last 20 days or so and haven't had issues