### PR TITLE
Issue #3536

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -2608,7 +2608,9 @@ namespace AAXClasses
         jassert (! pluginIds.contains (pluginID));
         pluginIds.add (pluginID);
 
+        #ifndef JucePlugin_EnhancedAudioSuite_Only
         properties->AddProperty (AAX_eProperty_PlugInID_Native, pluginID);
+        #endif
 
        #if ! (JucePlugin_AAXDisableAudioSuite || JucePlugin_EnhancedAudioSuite)
         properties->AddProperty (AAX_eProperty_PlugInID_AudioSuite,

--- a/modules/juce_audio_processors/juce_audio_processors.h
+++ b/modules/juce_audio_processors/juce_audio_processors.h
@@ -57,6 +57,15 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
 //==============================================================================
+
+#if JucePlugin_EnhancedAudioSuite
+#define RANDOM_AUDIO_ACCESS_SUPPORTED 1
+#if ! JUCE_MODULE_AVAILABLE_juce_audio_formats
+#error To compile random access support plug-in formats, you need to add the juce_audio_formats module!
+#endif
+#include <juce_audio_formats/juce_audio_formats.h>
+#endif
+
 /** Config: JUCE_PLUGINHOST_VST
     Enables the VST audio plugin hosting classes. You will need to have the VST2 SDK files in your header search paths. You can obtain the VST2 SDK files from on older version of the VST3 SDK.
 

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -327,6 +327,13 @@ void AudioProcessor::setPlayHead (AudioPlayHead* newPlayHead)
     playHead = newPlayHead;
 }
 
+#if RANDOM_AUDIO_ACCESS_SUPPORTED
+void AudioProcessor::setRandomAudioReader (AudioFormatReader* const newAudioFormatReader)
+{
+    randomAudioReader = newAudioFormatReader;
+}
+#endif
+
 void AudioProcessor::addListener (AudioProcessorListener* newListener)
 {
     const ScopedLock sl (listenerLock);
@@ -412,6 +419,12 @@ void AudioProcessor::setLatencySamples (int newLatency)
         latencySamples = newLatency;
         updateHostDisplay();
     }
+}
+
+bool AudioProcessor::isHighResolutionParameters(bool initialValue)
+{
+    static bool isHighResolutionParams = initialValue;
+    return isHighResolutionParams;
 }
 
 //==============================================================================
@@ -549,6 +562,44 @@ void AudioProcessor::processBypassed (AudioBuffer<floatType>& buffer, MidiBuffer
 
 void AudioProcessor::processBlockBypassed (AudioBuffer<float>&  buffer, MidiBuffer& midi)    { processBypassed (buffer, midi); }
 void AudioProcessor::processBlockBypassed (AudioBuffer<double>& buffer, MidiBuffer& midi)    { processBypassed (buffer, midi); }
+
+void AudioProcessor::analyseBlock (const AudioBuffer<const float>& buffer)
+{
+    ignoreUnused (buffer);
+    // If you hit this assertion then you've got analysis called but you haven't implement required callbacks.
+    jassertfalse;
+}
+
+void AudioProcessor::analyseBlock (const AudioBuffer<const double>& buffer)
+{
+    ignoreUnused (buffer);
+
+    // If you hit this assertion then either the caller called the double
+    // precision version of analyseBlock on a processor which does not support it
+    // (i.e. supportsDoublePrecisionProcessing() returns false), or the implementation
+    // of the AudioProcessor forgot to override the double precision version of this method
+    jassertfalse;
+}
+
+void AudioProcessor::prepareToAnalyse (double sampleRate, int maximumExpectedSamplesPerBlock, int numOfExpectedInputs)
+{
+    ignoreUnused (sampleRate, maximumExpectedSamplesPerBlock, numOfExpectedInputs);
+    // If you hit this assertion then you've got analysis called but you haven't implement required callbacks.
+    jassertfalse;
+};
+
+#if JucePlugin_EnhancedAudioSuite
+void AudioProcessor::getOfflineRenderOffset (int& startOffset, int& endOffset)
+{
+    startOffset = endOffset = 0;
+}
+#endif
+
+void AudioProcessor::analysisFinished ()
+{
+    // If you hit this assertion then you've got analysis called but you haven't implement required callbacks.
+    jassertfalse;
+};
 
 void AudioProcessor::processBlock (AudioBuffer<double>& buffer, MidiBuffer& midiMessages)
 {

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp
@@ -53,6 +53,8 @@ int AudioProcessorEditor::getControlParameterIndex (Component&)                {
 
 bool AudioProcessorEditor::supportsHostMIDIControllerPresence (bool)           { return true; }
 void AudioProcessorEditor::hostMIDIControllerIsAvailable (bool)                {}
+String AudioProcessorEditor::getCustomLabel (CustomHostLabel) { return String(); }
+
 
 void AudioProcessorEditor::initialise()
 {

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
@@ -116,6 +116,28 @@ public:
     */
     virtual void setScaleFactor (float newScale);
 
+    /** Used by the getCustomLabel() method. */
+    enum CustomHostLabel
+    {
+        AnalyzeLabel,
+        MonoModeLabel,
+        MultiInputModeLabel,
+        ClipByClipLabel,
+        WholeFileLabel,
+        ClipNameLabel,
+        ProgressLabel,
+        PlugInFileNameLabel,
+        PreviewLabel,
+        RenderLabel,
+        BypassLabel
+    };
+
+    /** Some types of plugin can call this to set different naming for their own UI labels.
+     Currently only AAX (AudioSuite) plugins will call this, and implementing it is optional.
+     */
+    virtual String getCustomLabel (CustomHostLabel buttonLabel);
+
+
     //==============================================================================
     /** Marks the host's editor window as resizable
 


### PR DESCRIPTION
Adds AudioSuite changes in Juce 6

I got the diff between Projucer-5.4.4 and Projucer-5.4.4_AudioSuite and applied the changes in Projucer-6.0.7

I built RoomToneMatch, opened Pro Tools, works as expected


Once this PR merges we need to build the new Projucer in Freddie and Ronnie